### PR TITLE
Create .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+    "parserOptions": {
+        "ecmaVersion": 2017
+    },
+
+    "env": {
+        "es6": true
+    }
+}


### PR DESCRIPTION
This updates the eslint format. I'm updating it to get fix the error "keyword const is reserved".